### PR TITLE
添加 Japanese Grammar Notes (jpnotes.dev) 到教程

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -11,3 +11,5 @@
 [Tatsumoto's guide to learning Japanese](https://tatsumoto.neocities.org/)：「A truly explosive approach to learning Japanese. Everything you need for your language study. Click here to start reading our Table of Contents! And if you feel lost and need help, you can also join our community.」
 
 [jpgramma - 日语语法指南](https://res.wokanxing.info/jpgramma/index.html)：外网广受好评的《Tae Kim Japanese Grammar Guide》的中文翻译。
+
+[Japanese Grammar Notes - 日语语法笔记](https://jpnotes.dev/)：免费的中英双语 JLPT N5→N2 语法笔记，每个语法点含含义、接续、例句和易混淆辨析，带振假名、例句朗读和可下载的 Anki 卡组。


### PR DESCRIPTION
重开 PR 指向 `master`(原 #48 因 `main` 分支删除已自动关闭)。

在 `docs/guide/README.md` 的教程列表中添加 [Japanese Grammar Notes](https://jpnotes.dev/),与已收录的 jpgramma 同属系统性语法教程:

- 75+ 节课,按 N5→N4→N3→N2 进阶,每个语法点含含义、接续规则、3+ 例句、易混淆语法辨析;
- 中英双语,可一键切换;
- 句子级**振假名**、例句**朗读音频**、暗色模式;
- 可下载 **Anki** 卡组(TSV + .apkg);
- 完全免费、无需注册、无广告。

利益声明:本人是 jpnotes.dev 的作者与维护者。感谢 review!